### PR TITLE
Disable startup logging for Bootstrap environment

### DIFF
--- a/spring-cloud-context/src/main/java/org/springframework/cloud/bootstrap/BootstrapApplicationListener.java
+++ b/spring-cloud-context/src/main/java/org/springframework/cloud/bootstrap/BootstrapApplicationListener.java
@@ -121,7 +121,9 @@ public class BootstrapApplicationListener
 				.profiles(environment.getActiveProfiles()).bannerMode(Mode.OFF)
 				.environment(bootstrapEnvironment)
 				.properties("spring.application.name:" + configName)
-				.registerShutdownHook(false).web(false);
+				.registerShutdownHook(false)
+				.logStartupInfo(false)
+				.web(false);
 		List<Class<?>> sources = new ArrayList<>();
 		for (String name : names) {
 			Class<?> cls = ClassUtils.resolveClassName(name, null);


### PR DESCRIPTION
Currently, two startup log entries will be emitted if Spring Cloud is configured in the project (assuming the app itself doesn't disable startup messages). Once for the Bootstrap context, once for the actual application. 

I'd imagine no one wants to see that. At least by default. Thoughts?

```
2016-03-09 10:46:39.108 [ INFO] [IID=Davids-MacBook-Pro-2.local::85122] [USER=]  -- exampleExampleServer                            : No active profile set, falling back to default profiles: default
2016-03-09 10:46:39.841 [ INFO] [IID=Davids-MacBook-Pro-2.local::85122] [USER=]  -- exampleExampleServer                            : Started ExampleServer in 1.165 seconds (JVM running for 1.795)

  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/
 :: Spring Boot ::        (v1.3.2.RELEASE)

2016-03-09 10:46:39.936 [ INFO] [IID=Davids-MacBook-Pro-2.local::85122] [USER=]  -- exampleExampleServer                            : No active profile set, falling back to default profiles: default
2016-03-09 10:46:41.320 [ INFO] [IID=Davids-MacBook-Pro-2.local::85122] [USER=]  -- org.reflections.Reflections                                 : Reflections took 77 ms to scan 1 urls, producing 41 keys and 122 values 
2016-03-09 10:46:42.260 [ INFO] [IID=Davids-MacBook-Pro-2.local::85122] [USER=]  -- o.apache.catalina.core.StandardService                      : Starting service Tomcat

...

2016-03-09 10:48:42.126 [ INFO] [IID=Davids-MacBook-Pro-2.local::85122] [USER=]  -- exampleExampleServer                            : Started Example in 2.633 seconds (JVM running for 66.828)

```
